### PR TITLE
Fix mobile toolbar and button functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
         </div>
         <div class="header-right">
             <button id="feedback-btn">feedback</button>
-            <button><a href="gallery.html">gallery</a></button>
+            <button id="gallery-btn">gallery</button>
         </div>
     </header>
     <div class="prompt-container">
@@ -247,6 +247,14 @@
             const submitBtn = document.getElementById('submit');
             if (submitBtn) {
                 submitBtn.addEventListener('click', submitDrawing);
+            }
+            
+            // Make entire gallery button tappable
+            const galleryBtn = document.getElementById('gallery-btn');
+            if (galleryBtn) {
+                galleryBtn.addEventListener('click', function() {
+                    window.location.href = 'gallery.html';
+                });
             }
             
         });

--- a/sketch.js
+++ b/sketch.js
@@ -1,32 +1,19 @@
 document.addEventListener('DOMContentLoaded', function() {
-  // Prevent scrolling and zooming on mobile
-  function preventScroll(e) {
-    e.preventDefault();
-    e.stopPropagation();
-    return false;
-  }
-  
-  // Add touch event listeners to prevent scrolling
-  document.addEventListener('touchstart', preventScroll, { passive: false });
-  document.addEventListener('touchmove', preventScroll, { passive: false });
-  document.addEventListener('touchend', preventScroll, { passive: false });
-  
-  // Prevent context menu on long press
-  document.addEventListener('contextmenu', preventScroll);
-  
-  // Prevent double-tap zoom
-  let lastTouchEnd = 0;
-  document.addEventListener('touchend', function(e) {
-    const now = (new Date()).getTime();
-    if (now - lastTouchEnd <= 300) {
-      e.preventDefault();
-    }
-    lastTouchEnd = now;
-  }, false);
+  // Prevent scrolling and zooming only within the canvas (scoped below)
   
   const canvas = document.getElementById('canvas');
   if (!canvas) return;
   const ctx = canvas.getContext('2d');
+  
+  // Prevent double-tap zoom ONLY on the canvas, not the whole document
+  let lastCanvasTouchEnd = 0;
+  canvas.addEventListener('touchend', function(e) {
+    const now = Date.now();
+    if (now - lastCanvasTouchEnd <= 300) {
+      e.preventDefault();
+    }
+    lastCanvasTouchEnd = now;
+  }, { passive: false });
 
   // Elements
   const colorInput = document.getElementById('color');

--- a/style.css
+++ b/style.css
@@ -102,6 +102,8 @@ header button {
   transition: all 160ms ease;
   display: inline-block;
   text-align: center;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
 }
 
 header button:hover {
@@ -417,6 +419,8 @@ p {
   padding: 0;
   position: relative;
   flex-shrink: 0;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .color-picker-btn:hover {
@@ -534,6 +538,8 @@ p {
   cursor: pointer;
   transition: all 0.2s ease;
   flex-shrink: 0;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .tool-btn:hover {
@@ -570,6 +576,8 @@ p {
   cursor: pointer;
   transition: all 0.2s ease;
   flex-shrink: 0;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .size-picker-btn:hover {
@@ -654,6 +662,8 @@ p {
   display: flex;
   align-items: center;
   justify-content: center;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
 }
 .toolbar button:hover {
   background: color-mix(in oklab, var(--accent) 8%, transparent);


### PR DESCRIPTION
Scope touch event prevention to the canvas and enable mobile taps on toolbar and header buttons.

Previously, global `document`-level touch event listeners prevented all taps and interactions outside the drawing canvas, causing toolbar overlays and header buttons to be unresponsive on mobile devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-51462330-ef83-4c8a-b1e8-7baccd81d29a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-51462330-ef83-4c8a-b1e8-7baccd81d29a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

